### PR TITLE
Add Poppins font to landing page

### DIFF
--- a/frontend/src/styles/Start/landing.css
+++ b/frontend/src/styles/Start/landing.css
@@ -1,8 +1,11 @@
 /* ---------- variables ---------- */
+
+/* Fuente base */
 :root {
   --bg-dark: #090b10;
   --primary: #3f9cff;
   --glass: rgba(255, 255, 255, 0.07);
+  font-family: 'Poppins', sans-serif;
 }
 
 /* ---------- progres bar ---------- */
@@ -54,7 +57,6 @@ body,
 
 .side-nav li {
   list-style: none;
-  font-family: monospace;
   font-size: 0.9rem;
   opacity: 0.4;
   white-space: nowrap;
@@ -125,6 +127,7 @@ body,
 
 .landing-title {
   font-size: clamp(2.7rem, 6vw, 5rem);
+  font-family: 'Poppins', sans-serif;
   letter-spacing: 2px;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.55);
 }
@@ -133,6 +136,7 @@ body,
   font-size: clamp(1rem, 2.4vw, 1.25rem);
   max-width: 32rem;
   margin-bottom: 1.6rem;
+  font-family: 'Poppins', sans-serif;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.55);
 }
 
@@ -208,6 +212,7 @@ body,
   margin-bottom: 2rem;
   font-weight: 700;
   text-transform: uppercase;
+  font-family: 'Poppins', sans-serif;
   font-size: clamp(1.8rem, 4vw, 2.6rem);
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.55);
 }
@@ -272,6 +277,13 @@ body,
   display: grid;
   gap: 2rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+/* ---------- contact ---------- */
+.contact-text {
+  margin-bottom: 1.6rem;
+  font-family: 'Poppins', sans-serif;
+  text-align: center;
 }
 
 /* ---------- footer ---------- */


### PR DESCRIPTION
## Summary
- set Poppins as global font for landing page
- use Poppins for titles and subtitles
- keep side navigation compatible with descriptive labels

## Testing
- `npm install`
- `CI=true npm test --silent` *(fails: Cannot find module '@testing-library/jest-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68417b9c12648320bdf8b7ce73d8085e